### PR TITLE
disconnect() event is emitted when transfer of data or error is ended

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules/
 npm-debug.log
 docs/
+.idea

--- a/components/ConvertCsvToMatrix.coffee
+++ b/components/ConvertCsvToMatrix.coffee
@@ -1,4 +1,3 @@
-
 noflo = require "noflo"
 csv = require "csv"
 
@@ -41,7 +40,9 @@ class ConvertCsvToMatrix extends noflo.Component
       csv().from.string(csvText, @parseOptions)
       .to.array (parsedRowArrays) =>
         @outPorts.out.send parsedRowArrays
+        @outPorts.out.disconnect()
       .on "error", (error) =>
         @outPorts.error.send { csvText: csvText, error: error.message }
+        @outPorts.error.disconnect()
 
 exports.getComponent = -> new ConvertCsvToMatrix()

--- a/components/ConvertCsvToObjectPerRow.coffee
+++ b/components/ConvertCsvToObjectPerRow.coffee
@@ -59,7 +59,9 @@ class ConvertCsvToObjectPerRow extends noflo.Component
           @outPorts.out.beginGroup { startTime: new Date(), headers: header }
       .on 'error', (error) =>
         @outPorts.error.send { csvText: csvText, error: error.message }
+        @outPorts.error.disconnect()
       .on "end", =>
         @outPorts.out.endGroup()
+        @outPorts.out.disconnect()
 
 exports.getComponent = -> new ConvertCsvToObjectPerRow()

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
   },
   "scripts": {
     "pretest": "./node_modules/.bin/coffeelint  -f coffeelint_config.json -r components spec",
-    "test": "./node_modules/.bin/mocha --compilers coffee:coffee-script spec/*"
+    "test": "./node_modules/.bin/mocha --compilers coffee:coffee-script spec"
   }
 }

--- a/spec/ConvertCsvToMatrixSpec.coffee
+++ b/spec/ConvertCsvToMatrixSpec.coffee
@@ -1,8 +1,7 @@
-if typeof process is "object" and process.title is "node"
-  chai = require "chai" unless chai
-  componentModule = require "../components/ConvertCsvToMatrix"
-  noflo = require "noflo"
-  util = require "util"
+chai = require "chai" unless chai
+componentModule = require "../components/ConvertCsvToMatrix"
+noflo = require "noflo"
+util = require "util"
 
 describe "ConvertCsvToMatrix", ->
   @timeout 5000  # Dear mocha, don't timeout tests that take less than 5 seconds. Kthxbai
@@ -45,6 +44,9 @@ describe "ConvertCsvToMatrix", ->
     it "should not send any error messages", ->
       chai.expect(errorMessages).to.deep.equal( [ ] )
 
+    it "should shutdown out port", ->
+      chai.expect(component.outPorts.out.sockets.map ((i) -> i.isConnected())).to.eql([false])
+
   describe "can report errors", ->
     before (done) ->
       outMessages.length = 0
@@ -61,3 +63,6 @@ describe "ConvertCsvToMatrix", ->
         csvText: '#Welcome\n"1","2","3","4"\n"a","b","c","d',
         error: "Quoted field not terminated at line 1"
       ] )
+
+    it "should shutdown error port", ->
+      chai.expect(component.outPorts.error.sockets.map ((i) -> i.isConnected())).to.eql([false])

--- a/spec/ConvertCsvToObjectPerRowSpec.coffee
+++ b/spec/ConvertCsvToObjectPerRowSpec.coffee
@@ -1,8 +1,7 @@
-if typeof process is "object" and process.title is "node"
-  chai = require "chai" unless chai
-  componentModule = require "../components/ConvertCsvToObjectPerRow"
-  noflo = require "noflo"
-  util = require "util"
+chai = require "chai" unless chai
+componentModule = require "../components/ConvertCsvToObjectPerRow"
+noflo = require "noflo"
+util = require "util"
 
 describe "ConvertCsvToObjectPerRow", ->
   @timeout 5000  # Dear mocha, don't timeout tests that take less than 5 seconds. Kthxbai
@@ -48,6 +47,9 @@ describe "ConvertCsvToObjectPerRow", ->
     it "should not send any error messages", ->
       chai.expect(errorMessages).to.deep.equal( [ ] )
 
+    it "should shutdown out port", ->
+      chai.expect(component.outPorts.out.sockets.map ((i) -> i.isConnected())).to.eql([false])
+
   describe "can report errors", ->
     before (done) ->
       outMessages.length = 0
@@ -66,3 +68,6 @@ describe "ConvertCsvToObjectPerRow", ->
         csvText: 'ts,year,ms,chars,age,date\n20322051544,1979.0,8.8017226E7,ABC,45,2000-01-01\n28392898392,1974.0,8.8392926E7,DEF,"23,2050-11-27\n',
         error: "Quoted field not terminated at line 1"
       ] )
+
+    it "should shutdown error port", ->
+      chai.expect(component.outPorts.error.sockets.map ((i) -> i.isConnected())).to.eql([false])


### PR DESCRIPTION
I suggest to include this patch to fix problem with dependent node that waits for end of data transmission from CSV node. (please find details [here](http://stackoverflow.com/questions/40895818/noflo-cannot-shutdown-execution))
Sorry that I forgot to move changes to separate branch, please let me know if any issues.